### PR TITLE
fix: ascii-stats splitting input won't work

### DIFF
--- a/Python/exams/ascii-stats/stats.py
+++ b/Python/exams/ascii-stats/stats.py
@@ -24,7 +24,7 @@ def main():
 
     try:
         coords = input("Please, enter the coordinates (x,y): ")
-        xs, ys = coords[1:-1].split(',')
+        xs, ys = coords.split(',')[0], coords.split(',')[1]
         x, y = int(xs), int(ys)
         size = int(input("Please, enter the square size: "))
     except ValueError:


### PR DESCRIPTION
The solution to `ascii-stats` exam won't work because of the wrong input splitting.

I tested with the `landscape.txt` file given in the [README.md](https://github.com/squillero/computer-sciences/blob/master/Python/exams/ascii-stats/README.md) and the result is:

<img width="393" alt="Screenshot 2023-01-26 at 18 22 03" src="https://user-images.githubusercontent.com/40398628/214907798-35e938a5-912f-4db5-89a2-62efed37d6c4.png">

And it should be (with the changes made):

<img width="398" alt="Screenshot 2023-01-26 at 18 23 21" src="https://user-images.githubusercontent.com/40398628/214907894-e43d7a46-01f0-432c-84ff-146d0a753339.png">

The code didn't work with the other `landscape.txt` files as well.